### PR TITLE
feat: adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Create a bug report to help us improve Keploy
+title: "[bug]: "
+labels: [bug]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for taking the time to fill out this bug report.
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered
+    options:
+    - label: I have searched the existing issues
+      required: true
+      
+- type: textarea
+  attributes:
+    label: Current behavior
+    description: A concise description of what you're experiencing and what you expect
+    placeholder: |
+      When I do <X>, <Y> happens and I see the error message attached below:
+      ```...```
+      What I expect is <Z>
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: Add steps to reproduce this behaviour, include console or network logs and screenshots
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+  validations:
+    required: true
+
+- type: dropdown
+  id: browser
+  attributes:
+      label: "Browser"
+      description: "What browser are you using ?"
+      options:
+        - Google Chrome
+        - Brave
+        - Microsoft Edge
+        - Mozilla Firefox
+        - Safari
+        - Opera
+        - Other
+  validations:
+      required: true
+
+- type: checkboxes
+  id: no-duplicate-issues
+  attributes:
+      label: "Checklist"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+
+        - label: "I have read the [Contributing Guidelines](https://github.com/keploy/website/blob/main/CONTRIBUTING.md)"
+          required: true
+
+        - label: "I am willing to work on this issue (blank for no)"
+          required: false
+
+- type: markdown
+  attributes:
+    value: |
+      Please add the respective Label to the Issue

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,13 +7,7 @@ body:
   attributes:
     value: |
       Thank you for taking the time to fill out this bug report.
-- type: checkboxes
-  attributes:
-    label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered
-    options:
-    - label: I have searched the existing issues
-      required: true
+
       
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Help and support
+    url: https://github.com/keploy/keploy#community-support
+    about: Reach out to us on our Slack channel or Discourse discussions or GitHub discussions.
+  - name: Dedicated support
+    url: mailto:hello@keploy.io
+    about: Write to us if you'd like dedicated support using Keploy

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
   - name: Help and support
-    url: https://github.com/keploy/keploy#community-support
+    url: https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA
     about: Reach out to us on our Slack channel or Discourse discussions or GitHub discussions.
   - name: Dedicated support
     url: mailto:hello@keploy.io

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,38 @@
+name: Documentation Update📄
+description: Suggest an improvement/addition in the Keploy Server Docs.
+title: "[docs]: "
+labels: [docs]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to file a Documentation update.
+      
+  - type: textarea
+    attributes:
+      label: What do you want to add to the docs? (please state reasons if any)
+      description: "Copy and paste the text currently in the documentation. If you want to improve graphs or photos, please provide a screenshot of the original."
+      
+  - type: textarea
+    attributes:
+      label: Where is this stated?
+      description: "Please explain why the statement needs to be updated. This can be because it is confusing, incorrect, spelling/grammatical errors, etc."
+      
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "Checklist"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+
+        - label: "I have read the [Contributing Guidelines](https://github.com/keploy/website/blob/main/CONTRIBUTING.md)"
+          required: true
+
+        - label: "I am willing to work on this issue (blank for no)"
+          required: false
+          
+  - type: markdown
+    attributes:
+      value: |
+        Please add the respective Label to the Issue

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest a feature to improve Keploy
+title: "[feature]: "
+labels: [feature]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for taking the time to request a feature for Keploy
+
+- type: textarea
+  attributes:
+    label: Summary
+    description: One paragraph description of the feature
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Why should this be worked on?
+    description: A concise description of the problems or use cases for this feature request
+  validations:
+    required: true
+
+- type: checkboxes
+  id: no-duplicate-issues
+  attributes:
+      label: "Checklist"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+
+        - label: "I have read the [Contributing Guidelines](https://github.com/keploy/website/blob/main/CONTRIBUTING.md)"
+          required: true
+
+        - label: "I am willing to work on this issue (blank for no)"
+          required: false
+
+- type: markdown
+  attributes:
+    value: |
+      Please add the respective Label to the Issue


### PR DESCRIPTION
**This closes [#453](https://github.com/keploy/keploy/issues/453)** 
**You can checkout the live demo  [here](https://github.com/IAmTamal/website/issues/new/choose)** 

## What i have been told to do ?

- Adding proper issue templates related for the `keploy/website` repository.
- There can be 3 different types of  issues : Bugs, Feature requests, Documentations.

<br>

## What are the changes that i have done ? 

- Added 3 different types of  issues templates for Bugs, Feature requests, Documentations.
- The blank issues are enables currently which can be closed by adding `blank_issues_enabled: false` to the `config.yml` file
- Added slack channel link to the `config.yml` as the previous URL redirected to just the repo, not the channel.
- Added an extra section in `bug.yml` so that the user can mention which browser they are using.
- Added an extra section called `checklist` containing 3 checks : 
   - Making sure they have read contribution guidelines.
   - Making sure they are not producing duplicate issues.
   - Making sure **if** they want to work on the issue.

<br>

## Screenshots

![image](https://user-images.githubusercontent.com/72851613/228614604-b08e6a83-28a6-4b96-b868-97e82bd4a8c1.png)

![image](https://user-images.githubusercontent.com/72851613/228614462-94a8b6d5-8438-4c39-95ba-616527881d73.png)
