### PR TITLE
[fix]: update CSS link in README.md file for the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ See the [ Code of Conduct](https://github.com/keploy/website/blob/main/code-of-c
 
 We use a variety of technologies to build the web interface and support the community. They include:
 
-- [Html](https://html.com/)
-- [Css]
+- [HTML](https://html.com/)
+- [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS)
 - [Javascript](https://www.javascript.com/)
 - [GitHub Actions](https://github.com/features/actions)
 


### PR DESCRIPTION
Fixes [#561](https://github.com/keploy/keploy/issues/561)

Fix the broken link in the [readme.md](https://github.com/keploy/website) of `keploy/website`.

<img width="371" alt="image" src="https://github.com/keploy/website/assets/100439627/e6b08495-afeb-4bac-b673-150972e0864e">
